### PR TITLE
Upgrades react-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "lodash.isequal": "4.5.0",
-    "react-svg": "^2.1.18"
+    "react-svg": "^2.2.5"
   },
   "jest": {
     "setupFiles": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,7 +4242,7 @@ react-move@^2.6.0:
     d3-interpolate "^1.1.3"
     d3-timer "^1.0.4"
 
-react-svg@^2.1.18:
+react-svg@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-svg/-/react-svg-2.2.5.tgz#8bc31cac72c0a24199fce66e66fcbc1d1bebb75b"
   dependencies:


### PR DESCRIPTION
Seems to fix #18 

@hugozap You were correct about the error.

Tested on two computers, upgrading the `react-svg` dependency seems to work. 